### PR TITLE
Add unit tests for 'git-elegant clone' command

### DIFF
--- a/src/test/fake-cd.bash
+++ b/src/test/fake-cd.bash
@@ -1,0 +1,9 @@
+# This is a mock for system function 'cd'
+#!/usr/bin/env bash
+set -e
+
+cd() {
+    sleep 0
+}
+
+export -f cd

--- a/src/test/git-elegant-clone.bats
+++ b/src/test/git-elegant-clone.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats -ex
+
+load commons
+load fake-read
+load fake-cd
+
+setup() {
+    fake-pass git clone
+    fake-pass git "clone https://github.com/extsoft/elegant-git.git"
+    fake-pass git "config --global user.name" aaa
+    fake-pass git "config --global user.email" aaa@aaa.com
+    fake-pass git "config --local user.name aaa"
+    fake-pass git "config --local user.email aaa@aaa.com"
+}
+
+@test "print message when run 'git-elegant clone'" {
+  run git-elegant clone
+  [[ "${lines[0]}" =~ "Specify URL to clone"  ]]
+}
+
+@test "exit code is 0 when run 'git-elegant clone'" {
+  run git-elegant clone https://github.com/extsoft/elegant-git.git
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Builtin command `cd` was mocked because fake-pass method doesn't work with builtin's.

Resolves #18