### PR TITLE
Move all config to 'git-elegant-configure'

### DIFF
--- a/src/main/git-elegant
+++ b/src/main/git-elegant
@@ -24,11 +24,6 @@ __mmn() {
 MASTER="master"
 RMASTER="origin/master"
 
-__config=(
-    'user.name'
-    'user.email'
-)
-
 commands() {
     echo "feature"
     echo "pull"
@@ -116,18 +111,6 @@ feature() {
     _validate "$1" "Feature name"
     pull $MASTER
     git checkout -b "$1"
-}
-
-_rewrite_config() {
-    # @todo #9 Move `user.name` and `user.email` configuration to the `git-elegant-configure` executable.
-    for line in "${__config[@]}"
-    do
-        local BASE=$(git config --global "$line")
-        __mmn "$line [$BASE]: "
-        read value
-        local VAR_VALUE=${value:-$BASE}
-        git config --local $line "$VAR_VALUE"
-    done
 }
 
 add() {

--- a/src/main/git-elegant-clone
+++ b/src/main/git-elegant-clone
@@ -5,5 +5,5 @@ default() {
     _validate "$1" "Clonable URL"
     git clone "$1"
     cd $(basename -s .git $1)
-    _rewrite_config
+    git elegant configure --local
 }

--- a/src/main/git-elegant-configure
+++ b/src/main/git-elegant-configure
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 set -e
 
-_core_comment_char_default="|"
 _core_comment_char_key="core.commentChar"
+_core_comment_char_default="|"
 _core_comment_char_message="commit message won't start with"
+
+_user_name_key="user.name"
+_user_name_default=$(git config --global "$_user_name_key")
+_user_name_message="your user name"
+
+_user_email_key="user.email"
+_user_email_default=$(git config --global "$_user_email_key")
+_user_email_message="your user email"
+
 
 _configure() {
     MODE=$1; shift
@@ -27,8 +36,8 @@ _configure() {
     done
 }
 
-GLOBALS=(_core_comment_char)
-LOCALS=(_core_comment_char)
+GLOBALS=(_core_comment_char _user_name _user_email)
+LOCALS=(_core_comment_char _user_name _user_email)
 
 default() {
     case "$1" in

--- a/src/main/git-elegant-init
+++ b/src/main/git-elegant-init
@@ -3,5 +3,5 @@ set -e
 
 default() {
     git init
-    _rewrite_config
+    git elegant configure --local
 }

--- a/src/test/git-elegant-clone.bats
+++ b/src/test/git-elegant-clone.bats
@@ -7,10 +7,7 @@ load fake-cd
 setup() {
     fake-pass git clone
     fake-pass git "clone https://github.com/extsoft/elegant-git.git"
-    fake-pass git "config --global user.name" aaa
-    fake-pass git "config --global user.email" aaa@aaa.com
-    fake-pass git "config --local user.name aaa"
-    fake-pass git "config --local user.email aaa@aaa.com"
+    fake-pass git "elegant configure --local"
 }
 
 @test "print message when run 'git-elegant clone'" {

--- a/src/test/git-elegant-configure.bats
+++ b/src/test/git-elegant-configure.bats
@@ -6,6 +6,14 @@ load fake-read
 setup() {
     fake-pass git "config --global core.commentChar" "|"
     fake-pass git "config --local core.commentChar" "|"
+
+    fake-pass git "config --global user.name" "UserName"
+    fake-pass git "config --global user.email" "UserEmail"
+
+    fake-pass git "config --global user.name UserName"
+    fake-pass git "config --global user.email UserEmail"
+    fake-pass git "config --local user.name UserName"
+    fake-pass git "config --local user.email UserEmail"
 }
 
 @test "'configure': exit code is 11 when run without arguments" {
@@ -27,11 +35,15 @@ setup() {
 @test "'configure': sequence of the configuration is correct when run with '--global' argument" {
   run git-elegant configure --global
   [[ "${lines[0]}" =~ "commit message won't start with [|]:" ]]
-  [ ${#lines[@]} == 1 ]
+  [[ "${lines[1]}" =~ "your user name [UserName]:" ]]
+  [[ "${lines[2]}" =~ "your user email [UserEmail]:" ]]
+  [ ${#lines[@]} == 3 ]
 }
 
 @test "'configure': sequence of the configuration is correct when run with '--local' argument" {
   run git-elegant configure --local
   [[ "${lines[0]}" =~ "commit message won't start with [|]:" ]]
-  [ ${#lines[@]} == 1 ]
+  [[ "${lines[1]}" =~ "your user name [UserName]:" ]]
+  [[ "${lines[2]}" =~ "your user email [UserEmail]:" ]]
+  [ ${#lines[@]} == 3 ]
 }

--- a/src/test/git-elegant-init.bats
+++ b/src/test/git-elegant-init.bats
@@ -5,10 +5,7 @@ load fake-read
 
 setup() {
     fake-pass git init
-    fake-pass git "config --global user.name" aaa
-    fake-pass git "config --global user.email" aaa@aaa.com
-    fake-pass git "config --local user.name aaa"
-    fake-pass git "config --local user.email aaa@aaa.com"
+    fake-pass git "elegant configure --local"
 }
 
 @test "exit code is 0 when run 'git-elegant init'" {


### PR DESCRIPTION
Move configuration of `user.name` and `user.email` to separate executable `git-elegant-configure` and remove redundant method `_rewrite_config()`.
Update unit tests for `git-elegant-configure`.
Update commands used `_rewrite_config()`.
Update tests for `init` and `clone` commands.

Closes #39 