### PR TITLE
Make 'git-elegant' calls in scripts unified

### DIFF
--- a/src/main/git-elegant-clone
+++ b/src/main/git-elegant-clone
@@ -5,5 +5,5 @@ default() {
     _validate "$1" "Clonable URL"
     git clone "$1"
     cd $(basename -s .git $1)
-    git elegant configure --local
+    git-elegant configure --local
 }

--- a/src/main/git-elegant-init
+++ b/src/main/git-elegant-init
@@ -3,5 +3,5 @@ set -e
 
 default() {
     git init
-    git elegant configure --local
+    git-elegant configure --local
 }

--- a/src/test/git-elegant-clone.bats
+++ b/src/test/git-elegant-clone.bats
@@ -7,7 +7,13 @@ load fake-cd
 setup() {
     fake-pass git clone
     fake-pass git "clone https://github.com/extsoft/elegant-git.git"
-    fake-pass git "elegant configure --local"
+
+    fake-pass git "config --global user.name" "UserName"
+    fake-pass git "config --global user.email" "UserEmail"
+
+    fake-pass git "config --local core.commentChar"
+    fake-pass git "config --local user.name UserName"
+    fake-pass git "config --local user.email UserEmail"
 }
 
 @test "print message when run 'git-elegant clone'" {

--- a/src/test/git-elegant-init.bats
+++ b/src/test/git-elegant-init.bats
@@ -5,7 +5,13 @@ load fake-read
 
 setup() {
     fake-pass git init
-    fake-pass git "elegant configure --local"
+
+    fake-pass git "config --global user.name" "UserName"
+    fake-pass git "config --global user.email" "UserEmail"
+
+    fake-pass git "config --local core.commentChar"
+    fake-pass git "config --local user.name UserName"
+    fake-pass git "config --local user.email UserEmail"
 }
 
 @test "exit code is 0 when run 'git-elegant init'" {


### PR DESCRIPTION
Use 'git-elegant' calls instead of 'git elegant'.

Closes #74