### PR TITLE
Fix 'configure' command to handle configs with whitespaces

### DIFF
--- a/src/main/git-elegant-configure
+++ b/src/main/git-elegant-configure
@@ -47,7 +47,7 @@ _configure() {
                 fi
             else
                 if [ -n "${answer}" ]; then
-                    git config $MODE $(eval "echo -n \$${f}_key") $answer
+                    git config $MODE $(eval "echo -n \$${f}_key") "$answer"
                 fi
             fi
         done


### PR DESCRIPTION
Part of fixing of #83.