### PR TITLE
 Add whitespace issues configuration to 'configure' command

### DIFF
--- a/src/main/git-elegant-configure
+++ b/src/main/git-elegant-configure
@@ -13,6 +13,10 @@ _user_email_key="user.email"
 _user_email_default=$(git config --global "$_user_email_key")
 _user_email_message="your user email"
 
+_apply_whitespace_key="apply.whitespace"
+_apply_whitespace_default="fix"
+_apply_whitespace_message="whitespace issues on patching"
+
 
 _configure() {
     MODE=$1; shift
@@ -36,8 +40,8 @@ _configure() {
     done
 }
 
-GLOBALS=(_core_comment_char _user_name _user_email)
-LOCALS=(_core_comment_char _user_name _user_email)
+GLOBALS=(_core_comment_char _user_name _user_email _apply_whitespace)
+LOCALS=(_core_comment_char _user_name _user_email _apply_whitespace)
 
 default() {
     case "$1" in

--- a/src/test/git-elegant-configure.bats
+++ b/src/test/git-elegant-configure.bats
@@ -4,16 +4,19 @@ load commons
 load fake-read
 
 setup() {
-    fake-pass git "config --global core.commentChar" "|"
-    fake-pass git "config --local core.commentChar" "|"
-
     fake-pass git "config --global user.name" "UserName"
     fake-pass git "config --global user.email" "UserEmail"
+
+    fake-pass git "config --global core.commentChar"
+    fake-pass git "config --local core.commentChar"
 
     fake-pass git "config --global user.name UserName"
     fake-pass git "config --global user.email UserEmail"
     fake-pass git "config --local user.name UserName"
     fake-pass git "config --local user.email UserEmail"
+
+    fake-pass git "config --global apply.whitespace fix"
+    fake-pass git "config --local apply.whitespace fix"
 }
 
 @test "'configure': exit code is 11 when run without arguments" {
@@ -34,16 +37,18 @@ setup() {
 
 @test "'configure': sequence of the configuration is correct when run with '--global' argument" {
   run git-elegant configure --global
-  [[ "${lines[0]}" =~ "commit message won't start with [|]:" ]]
-  [[ "${lines[1]}" =~ "your user name [UserName]:" ]]
-  [[ "${lines[2]}" =~ "your user email [UserEmail]:" ]]
-  [ ${#lines[@]} == 3 ]
+  [ "${lines[0]}" = "commit message won't start with [|]: " ]
+  [ "${lines[1]}" = "your user name [UserName]: " ]
+  [ "${lines[2]}" = "your user email [UserEmail]: " ]
+  [ "${lines[3]}" = "whitespace issues on patching [fix]: " ]
+  [ ${#lines[@]} -eq 4 ]
 }
 
 @test "'configure': sequence of the configuration is correct when run with '--local' argument" {
   run git-elegant configure --local
-  [[ "${lines[0]}" =~ "commit message won't start with [|]:" ]]
-  [[ "${lines[1]}" =~ "your user name [UserName]:" ]]
-  [[ "${lines[2]}" =~ "your user email [UserEmail]:" ]]
-  [ ${#lines[@]} == 3 ]
+  [ "${lines[0]}" = "commit message won't start with [|]: " ]
+  [ "${lines[1]}" = "your user name [UserName]: " ]
+  [ "${lines[2]}" = "your user email [UserEmail]: " ]
+  [ "${lines[3]}" = "whitespace issues on patching [fix]: " ]
+  [ ${#lines[@]} -eq 4 ]
 }


### PR DESCRIPTION
Added only configuration:
```
[apply]
    whitespace = fix
```
For more information take a look at #58.

Closes #58